### PR TITLE
Add a more intutive API 

### DIFF
--- a/src/module/API.js
+++ b/src/module/API.js
@@ -1,0 +1,109 @@
+import { Butler } from "./butler";
+import { Sidekick } from "./sidekick";
+import { Triggler } from "./triggler/triggler";
+
+/**
+ * Create a new API class and export it as default
+ */
+const API = {
+
+  /**
+   * Retrieve a registered trigger with id
+   * @param {string} id the id of the trigger
+   * @returns {Object} trigger The trigger.
+   * @returns {string} [trigger.attribute] an optional string property
+   * @returns {string} [trigger.category] an optional string property
+   * @returns {boolean} [trigger.notZero] an optional boolean property
+   * @returns {boolean} [trigger.npcOnly] an optional boolean property
+   * @returns {boolean} [trigger.pcOnly] an optional boolean property
+   * @returns {string} [trigger.operator] an optional string property
+   * @returns {string} [trigger.property1] an optional string property
+   * @returns {string} [trigger.property2] an optional string property
+   * @returns {('simple'|'advanced')} [trigger.triggerType] an string property
+   * @returns {string} [trigger.id] an optional string property
+   * @returns {string} [trigger.value] an optional string property
+   * @returns {string} [trigger.advancedName] Only with triggerType === 'advanced'
+   */
+  retrieveTriggler(id) {
+    const triggers = Sidekick.getSetting(Butler.SETTING_KEYS.triggler?.triggers);
+    const existingTrigger = triggers.find((t) => t.id && t.id === id);
+    return existingTrigger;
+  },
+
+  /**
+   * Check the specific trigger is hooked from this update
+   * @param {Actor|Token|TokenDocument} entity the Actor or Token entity to reference
+   * @param {string} id the id of the trigger
+   * @param {Object} update the object update to check
+   * @returns {boolean} the trigger is been evaluate positively or negatively
+   */
+  isTrigglerPositive(entity, id, update){
+    if(!entity) {
+      ui.notifications.warn(game.i18n.localize(`No entity is been passed`));
+      return;
+    }
+    if(!id) {
+      ui.notifications.warn(game.i18n.localize(`No trigger id is been passed`));
+      return;
+    }
+    const trigger = this.retrieveTriggler(id);
+    if(!trigger) {
+      ui.notifications.warn(game.i18n.localize(`No trigger found with id '${id}'`));
+      return;
+    }
+		const entityType =
+			entity instanceof Actor
+				? "Actor"
+				: entity instanceof Token || entity instanceof TokenDocument
+				? "Token"
+				: null;
+
+		if (!entityType) {
+      ui.notifications.warn(game.i18n.localize(`No valid entity found for '${entity}'`));
+			return;
+		}
+
+    const dataProp = `system`;
+		const dataDataProp = `system`;
+
+    const triggers = Triggler._prepareUpdate(entity, update, dataProp, dataDataProp, [trigger]);
+    return triggers?.length > 0 ? true : false;
+
+  },
+
+  executeTriggler(entity, id) {
+    if(!entity) {
+      ui.notifications.warn(game.i18n.localize(`No entity is been passed`));
+      return;
+    }
+    if(!id) {
+      ui.notifications.warn(game.i18n.localize(`No trigger id is been passed`));
+      return;
+    }
+    const trigger = this.retrieveTriggler(id);
+    if(!trigger) {
+      ui.notifications.warn(game.i18n.localize(`No trigger found with id '${id}'`));
+      return;
+    }
+		const entityType =
+			entity instanceof Actor
+				? "Actor"
+				: entity instanceof Token || entity instanceof TokenDocument
+				? "Token"
+				: null;
+
+		if (!entityType) {
+      ui.notifications.warn(game.i18n.localize(`No valid entity found for '${entity}'`));
+			return;
+		}
+
+    const dataProp = `system`;
+		const dataDataProp = `system`;
+
+    Triggler._processUpdate(entity, update, dataProp, dataDataProp, [trigger]);
+  },
+  
+  
+};
+
+export default API;

--- a/src/module/condition-lab-triggler.js
+++ b/src/module/condition-lab-triggler.js
@@ -1,7 +1,7 @@
 /* -------------------------------------------- */
 /*                    Imports                   */
 /* -------------------------------------------- */
-import { Butler as BUTLER } from "./butler.js";
+import { Butler as BUTLER, Butler } from "./butler.js";
 import { libWrapper } from "./libWrapper.js";
 import { registerSettings } from "./settings.js";
 import { Sidekick } from "./sidekick.js";
@@ -16,6 +16,7 @@ import { ConditionLab } from "./enhanced-conditions/condition-lab.js";
 import { TrigglerForm } from "./triggler/triggler-form.js";
 import { Triggler } from "./triggler/triggler.js";
 import MigrationHelper from "./utils/migration.js";
+import API from "./API.js";
 
 /* -------------------------------------------- */
 /*                    System                    */
@@ -102,6 +103,13 @@ Hooks.on("init", () => {
 		precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
 	});
 	postInit();
+});
+
+/* ------------------- Setup ------------------- */
+
+Hooks.on("setup", () => {
+	const data = game.modules.get(Butler.NAME);
+	data.api = API;
 });
 
 function postInit() {


### PR DESCRIPTION
NOTE: This code is a beta I stopped before going any further to ask if you are okay with the idea.

I started with the idea of integrating the trigger mechanism into another module for example silly things like "Run this macro only if the current state of the actor triggers the specific trigger, but without launching  any code on the actor it just check if it triggers it."

This is because I could exploit a lot of stuff already done in this module, but I found the api unintuitive, but maybe that's my problem... to make it more "standard" I created a separate API class and the three methods I could exploit in theory for my use case.

Specifically I would need your opinion on the code for the `_processUpdate` method which I have separated into two functions `_prepareUpdate` and `_processUpdate`.
