### PR TITLE
Run npm run lint:fix.  Add a pre-commit hook so that this is always run.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/src/module/enhanced-conditions/condition-lab.js
+++ b/src/module/enhanced-conditions/condition-lab.js
@@ -620,10 +620,10 @@ export class ConditionLab extends FormApplication {
 
 		if (!conditionEffect) return;
 
-		if (!hasProperty(conditionEffect, `flags.condition-lab-triggler.conditionId`)) {
+		if (!hasProperty(conditionEffect, "flags.condition-lab-triggler.conditionId")) {
 			setProperty(
 				conditionEffect,
-				`flags.condition-lab-triggler.conditionId`,
+				"flags.condition-lab-triggler.conditionId",
 				conditionId
 			);
 		}

--- a/src/module/enhanced-conditions/enhanced-conditions.js
+++ b/src/module/enhanced-conditions/enhanced-conditions.js
@@ -1194,6 +1194,9 @@ export class EnhancedConditions {
 	 * Gets a condition by name from the Condition Map
 	 * @param {*} conditionName
 	 * @param {*} options.warn
+	 * @param map
+	 * @param root0
+	 * @param root0.warn
 	 */
 	static getCondition(conditionName, map = null, { warn = false } = {}) {
 		if (!conditionName) {


### PR DESCRIPTION
Both `husky` and `lint-staged` are already installed as `devDependencies` but no git hook has been added.  Adding a `pre-commit` script will ensure that linting is always run on files about to be commited.